### PR TITLE
RHCLOUD-34945 - Add pipeline to sync protos

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -1,0 +1,31 @@
+name: sync-protos
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *' # every 6 hours.
+
+
+jobs:
+  build:
+    name: Sync protos to clients
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clone inventory-api repo
+        run: git clone --depth=1 https://github.com/project-kessel/inventory-api.git
+      - name: Copy proto files
+        run: |
+          cp -r inventory-api/api/kessel/inventory/v1/*.proto src/main/proto/kessel/inventory/v1/
+          cp -r inventory-api/api/kessel/inventory/v1beta1/*.proto src/main/proto/kessel/inventory/v1beta1/
+          rm -rf inventory-api/
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'Sync updated proto files'
+          title: Update protos
+          

--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -28,4 +28,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'Sync updated proto files'
           title: Update protos
+      
           

--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Copy proto files
         run: |
           cp -r inventory-api/api/kessel/inventory/v1/*.proto src/main/proto/kessel/inventory/v1/
-          cp -r inventory-api/api/kessel/inventory/v1beta1/*.proto src/main/proto/kessel/inventory/v1beta1/
+          cp -r inventory-api/api/kessel/inventory/v1beta1/relationships/*.proto src/main/proto/kessel/inventory/v1beta1/
+          cp -r inventory-api/api/kessel/inventory/v1beta1/resources/*.proto src/main/proto/kessel/inventory/v1beta1/
           rm -rf inventory-api/
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
## Changes
Mirror changes made to  [relations-client-java #26](https://github.com/project-kessel/relations-client-java/pull/26) 
- Add Github actions pipeline that will sync proto files with inventory-api

