### PR TITLE
update common lib version, add applicationscope annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,12 @@
         <dependency>
             <groupId>org.project-kessel</groupId>
             <artifactId>common-client-java</artifactId>
-            <version>0.1</version>
+            <version>0.2</version>
         </dependency>
         <dependency>
             <groupId>build.buf</groupId>
             <artifactId>protovalidate</artifactId>
-            <version>0.3.2</version>
+            <version>0.2.1</version>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>

--- a/src/main/java/org/project_kessel/inventory/client/CDIManagedInventoryClients.java
+++ b/src/main/java/org/project_kessel/inventory/client/CDIManagedInventoryClients.java
@@ -32,31 +32,37 @@ public class CDIManagedInventoryClients {
     }
 
     @Produces
+    @ApplicationScoped
     public RhelHostClient getHostClient(InventoryGrpcClientsManager manager) {
         return manager.getHostClient();
     }
 
     @Produces
+    @ApplicationScoped
     public InventoryHealthClient getHealthClient(InventoryGrpcClientsManager manager) {
         return manager.getHealthClient();
     }
 
     @Produces
+    @ApplicationScoped
     public K8sClustersClient getK8sClustersClient(InventoryGrpcClientsManager manager) {
         return manager.getK8sClustersClient();
     }
 
     @Produces
+    @ApplicationScoped
     public K8sPolicyClient getKesselK8sPolicyClient(InventoryGrpcClientsManager manager) {
         return manager.getKesselK8sPolicyClient();
     }
 
     @Produces
+    @ApplicationScoped
     public K8SPolicyIsPropagatedToK8SClusterClient getKesselK8SPolicyIsPropagatedToK8SClusterClient(InventoryGrpcClientsManager manager) {
         return manager.getKesselK8SPolicyIsPropagatedToK8SClusterClient();
     }
 
     @Produces
+    @ApplicationScoped
     public NotificationsIntegrationClient getNotificationsIntegrationClient(InventoryGrpcClientsManager manager) {
         return manager.getNotificationsIntegrationClient();
     }


### PR DESCRIPTION
Fixes for the client when used with Quarkus:

* Bump common-client-java to support @ApplicationScoped beans (for the cases where synthetic no-arg constructors can only be created when the abstract superclass has a no-args constructor).
* Downgrade protovalidate to a version that supports the version of protoc that is compatible with the code generation plugin.