### PR TITLE
Add check client to manager for clients to inject

### DIFF
--- a/src/main/java/org/project_kessel/inventory/client/CDIManagedInventoryClients.java
+++ b/src/main/java/org/project_kessel/inventory/client/CDIManagedInventoryClients.java
@@ -67,4 +67,10 @@ public class CDIManagedInventoryClients {
     public NotificationsIntegrationClient getNotificationsIntegrationClient(InventoryGrpcClientsManager manager) {
         return manager.getNotificationsIntegrationClient();
     }
+
+    @Produces
+    @ApplicationScoped
+    public KesselCheckClient getKesselCheckClient(InventoryGrpcClientsManager manager) {
+        return manager.getKesselCheckClient();
+    }
 }

--- a/src/main/java/org/project_kessel/inventory/client/InventoryGrpcClientsManager.java
+++ b/src/main/java/org/project_kessel/inventory/client/InventoryGrpcClientsManager.java
@@ -62,4 +62,8 @@ public class InventoryGrpcClientsManager extends KesselClientsManager {
     public NotificationsIntegrationClient getNotificationsIntegrationClient() {
         return new NotificationsIntegrationClient(channel);
     }
+
+    public KesselCheckClient getKesselCheckClient() {
+        return new KesselCheckClient(channel);
+    }
 }


### PR DESCRIPTION
Realized the kessel check client was not added to the manager and thus wasn't injected properly in quarkus apps. Required for usage with notifications.