### PR TITLE
RHCLOUD-38917 - API protos for Inventory managed zookie solution 

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -22,6 +22,7 @@ jobs:
           cp -r inventory-api/api/kessel/inventory/v1/*.proto src/main/proto/kessel/inventory/v1/
           cp -r inventory-api/api/kessel/inventory/v1beta1/relationships/*.proto src/main/proto/kessel/inventory/v1beta1/
           cp -r inventory-api/api/kessel/inventory/v1beta1/resources/*.proto src/main/proto/kessel/inventory/v1beta1/
+          cp -r inventory-api/api/kessel/inventory/v1beta1/authz/*.proto src/main/proto/kessel/inventory/v1beta1/
           rm -rf inventory-api/
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/src/main/java/org/project_kessel/inventory/client/CDIManagedInventoryClients.java
+++ b/src/main/java/org/project_kessel/inventory/client/CDIManagedInventoryClients.java
@@ -67,4 +67,10 @@ public class CDIManagedInventoryClients {
     public NotificationsIntegrationClient getNotificationsIntegrationClient(InventoryGrpcClientsManager manager) {
         return manager.getNotificationsIntegrationClient();
     }
+
+    @Produces
+    @ApplicationScoped
+    public KesselCheckClient getKesselCheckClient(InventoryGrpcClientsManager manager) {
+        return manager.getKesselCheckClient();
+    }
 }

--- a/src/main/java/org/project_kessel/inventory/client/InventoryGrpcClientsManager.java
+++ b/src/main/java/org/project_kessel/inventory/client/InventoryGrpcClientsManager.java
@@ -62,4 +62,8 @@ public class InventoryGrpcClientsManager extends KesselClientsManager {
     public NotificationsIntegrationClient getNotificationsIntegrationClient() {
         return new NotificationsIntegrationClient(channel);
     }
+
+    public KesselCheckClient getKesselCheckClient() {
+        return new KesselCheckClient(channel);
+    }
 }

--- a/src/main/java/org/project_kessel/inventory/client/KesselCheckClient.java
+++ b/src/main/java/org/project_kessel/inventory/client/KesselCheckClient.java
@@ -2,12 +2,10 @@ package org.project_kessel.inventory.client;
 
 import java.util.logging.Logger;
 
-import org.project_kessel.api.inventory.v1beta1.authz.CheckForCreateRequest;
-import org.project_kessel.api.inventory.v1beta1.authz.CheckForCreateResponse;
 import org.project_kessel.api.inventory.v1beta1.authz.CheckForUpdateRequest;
 import org.project_kessel.api.inventory.v1beta1.authz.CheckForUpdateResponse;
-import org.project_kessel.api.inventory.v1beta1.authz.CheckForViewRequest;
-import org.project_kessel.api.inventory.v1beta1.authz.CheckForViewResponse;
+import org.project_kessel.api.inventory.v1beta1.authz.CheckRequest;
+import org.project_kessel.api.inventory.v1beta1.authz.CheckResponse;
 import org.project_kessel.api.inventory.v1beta1.authz.KesselCheckServiceGrpc;
 import org.project_kessel.clients.KesselClient;
 
@@ -24,19 +22,19 @@ public class KesselCheckClient extends KesselClient<KesselCheckServiceGrpc.Kesse
     }
 
 
-    public CheckForViewResponse CheckForView(CheckForViewRequest request) {
-        return blockingStub.checkForView(request);
+    public CheckResponse Check(CheckRequest request) {
+        return blockingStub.check(request);
     }
 
-    public void CheckForView(CheckForViewRequest request, StreamObserver<CheckForViewResponse> responObserver) {
-        asyncStub.checkForView(request, responObserver);
+    public void Check(CheckRequest request, StreamObserver<CheckResponse> responObserver) {
+        asyncStub.check(request, responObserver);
     }
     
-    public Uni<CheckForViewResponse> CheckForViewUni(CheckForViewRequest request) {
-        final UnicastProcessor<CheckForViewResponse> responseProcessor = UnicastProcessor.create();
-        var streamObserver = new StreamObserver<CheckForViewResponse>() {
+    public Uni<CheckResponse> CheckUni(CheckRequest request) {
+        final UnicastProcessor<CheckResponse> responseProcessor = UnicastProcessor.create();
+        var streamObserver = new StreamObserver<CheckResponse>() {
             @Override
-            public void onNext(CheckForViewResponse response) {
+            public void onNext(CheckResponse response) {
                 responseProcessor.onNext(response);
             }
 
@@ -51,7 +49,7 @@ public class KesselCheckClient extends KesselClient<KesselCheckServiceGrpc.Kesse
             }
         };
         var uni = Uni.createFrom().publisher(responseProcessor);
-        CheckForView(request, streamObserver);
+        Check(request, streamObserver);
         return uni;
     }
 
@@ -84,38 +82,6 @@ public class KesselCheckClient extends KesselClient<KesselCheckServiceGrpc.Kesse
         };
         var uni = Uni.createFrom().publisher(responseProcessor);
         CheckForUpdate(request, streamObserver);
-        return uni;
-    }
-
-
-    public CheckForCreateResponse CheckForCreate(CheckForCreateRequest request) {
-        return blockingStub.checkForCreate(request);
-    }
-
-    public void CheckForCreate(CheckForCreateRequest request, StreamObserver<CheckForCreateResponse> responObserver) {
-        asyncStub.checkForCreate(request, responObserver);
-    }
-    
-    public Uni<CheckForCreateResponse> CheckForCreateUni(CheckForCreateRequest request) {
-        final UnicastProcessor<CheckForCreateResponse> responseProcessor = UnicastProcessor.create();
-        var streamObserver = new StreamObserver<CheckForCreateResponse>() {
-            @Override
-            public void onNext(CheckForCreateResponse response) {
-                responseProcessor.onNext(response);
-            }
-
-            @Override
-            public void onError(Throwable t) {
-                responseProcessor.onError(t);
-            }
-
-            @Override
-            public void onCompleted() {
-                responseProcessor.onComplete();
-            }
-        };
-        var uni = Uni.createFrom().publisher(responseProcessor);
-        CheckForCreate(request, streamObserver);
         return uni;
     }
 }

--- a/src/main/java/org/project_kessel/inventory/client/KesselCheckClient.java
+++ b/src/main/java/org/project_kessel/inventory/client/KesselCheckClient.java
@@ -1,0 +1,121 @@
+package org.project_kessel.inventory.client;
+
+import java.util.logging.Logger;
+
+import org.project_kessel.api.inventory.v1beta1.authz.CheckForCreateRequest;
+import org.project_kessel.api.inventory.v1beta1.authz.CheckForCreateResponse;
+import org.project_kessel.api.inventory.v1beta1.authz.CheckForUpdateRequest;
+import org.project_kessel.api.inventory.v1beta1.authz.CheckForUpdateResponse;
+import org.project_kessel.api.inventory.v1beta1.authz.CheckForViewRequest;
+import org.project_kessel.api.inventory.v1beta1.authz.CheckForViewResponse;
+import org.project_kessel.api.inventory.v1beta1.authz.KesselCheckServiceGrpc;
+import org.project_kessel.clients.KesselClient;
+
+import io.grpc.Channel;
+import io.grpc.stub.StreamObserver;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
+
+public class KesselCheckClient extends KesselClient<KesselCheckServiceGrpc.KesselCheckServiceStub, KesselCheckServiceGrpc.KesselCheckServiceBlockingStub> {
+    private static final Logger logger = Logger.getLogger(RhelHostClient.class.getName());
+
+    KesselCheckClient(Channel channel) {
+        super(KesselCheckServiceGrpc.newStub(channel), KesselCheckServiceGrpc.newBlockingStub(channel));
+    }
+
+
+    public CheckForViewResponse CheckForView(CheckForViewRequest request) {
+        return blockingStub.checkForView(request);
+    }
+
+    public void CheckForView(CheckForViewRequest request, StreamObserver<CheckForViewResponse> responObserver) {
+        asyncStub.checkForView(request, responObserver);
+    }
+    
+    public Uni<CheckForViewResponse> CheckForViewUni(CheckForViewRequest request) {
+        final UnicastProcessor<CheckForViewResponse> responseProcessor = UnicastProcessor.create();
+        var streamObserver = new StreamObserver<CheckForViewResponse>() {
+            @Override
+            public void onNext(CheckForViewResponse response) {
+                responseProcessor.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                responseProcessor.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                responseProcessor.onComplete();
+            }
+        };
+        var uni = Uni.createFrom().publisher(responseProcessor);
+        CheckForView(request, streamObserver);
+        return uni;
+    }
+
+
+    public CheckForUpdateResponse CheckForUpdate(CheckForUpdateRequest request) {
+        return blockingStub.checkForUpdate(request);
+    }
+
+    public void CheckForUpdate(CheckForUpdateRequest request, StreamObserver<CheckForUpdateResponse> responObserver) {
+        asyncStub.checkForUpdate(request, responObserver);
+    }
+    
+    public Uni<CheckForUpdateResponse> CheckForUpdateUni(CheckForUpdateRequest request) {
+        final UnicastProcessor<CheckForUpdateResponse> responseProcessor = UnicastProcessor.create();
+        var streamObserver = new StreamObserver<CheckForUpdateResponse>() {
+            @Override
+            public void onNext(CheckForUpdateResponse response) {
+                responseProcessor.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                responseProcessor.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                responseProcessor.onComplete();
+            }
+        };
+        var uni = Uni.createFrom().publisher(responseProcessor);
+        CheckForUpdate(request, streamObserver);
+        return uni;
+    }
+
+
+    public CheckForCreateResponse CheckForCreate(CheckForCreateRequest request) {
+        return blockingStub.checkForCreate(request);
+    }
+
+    public void CheckForCreate(CheckForCreateRequest request, StreamObserver<CheckForCreateResponse> responObserver) {
+        asyncStub.checkForCreate(request, responObserver);
+    }
+    
+    public Uni<CheckForCreateResponse> CheckForCreateUni(CheckForCreateRequest request) {
+        final UnicastProcessor<CheckForCreateResponse> responseProcessor = UnicastProcessor.create();
+        var streamObserver = new StreamObserver<CheckForCreateResponse>() {
+            @Override
+            public void onNext(CheckForCreateResponse response) {
+                responseProcessor.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                responseProcessor.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                responseProcessor.onComplete();
+            }
+        };
+        var uni = Uni.createFrom().publisher(responseProcessor);
+        CheckForCreate(request, streamObserver);
+        return uni;
+    }
+}

--- a/src/main/java/org/project_kessel/inventory/client/NotificationsIntegrationClient.java
+++ b/src/main/java/org/project_kessel/inventory/client/NotificationsIntegrationClient.java
@@ -2,6 +2,7 @@ package org.project_kessel.inventory.client;
 
 import io.grpc.Channel;
 import io.grpc.stub.StreamObserver;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import org.project_kessel.api.inventory.v1beta1.resources.*;
@@ -110,6 +111,35 @@ public class NotificationsIntegrationClient extends KesselClient<KesselNotificat
         var uni = Uni.createFrom().publisher(responseProcessor);
         DeleteNotificationsIntegration(request, streamObserver);
         return uni;
+    }
+
+    public void listNotificationsIntegrations(
+            ListNotificationsIntegrationsRequest request,
+            StreamObserver<ListNotificationsIntegrationsResponse> responseObserver) {
+        asyncStub.listNotificationsIntegrations(request, responseObserver);
+    }
+
+    public Multi<ListNotificationsIntegrationsResponse> listNotificationsIntegrations(ListNotificationsIntegrationsRequest request) {
+        final UnicastProcessor<ListNotificationsIntegrationsResponse> responseProcessor = UnicastProcessor.create();
+        var streamObserver = new StreamObserver<ListNotificationsIntegrationsResponse>() {
+            @Override
+            public void onNext(ListNotificationsIntegrationsResponse response) {
+                responseProcessor.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                responseProcessor.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                responseProcessor.onComplete();
+            }
+        };
+        var multi = Multi.createFrom().publisher(responseProcessor);
+        listNotificationsIntegrations(request, streamObserver);
+        return multi;
     }
 }
 

--- a/src/main/proto/kessel/inventory/v1beta1/authz/check.proto
+++ b/src/main/proto/kessel/inventory/v1beta1/authz/check.proto
@@ -1,0 +1,99 @@
+syntax = "proto3";
+
+package kessel.inventory.v1beta1.authz;
+
+import "google/api/annotations.proto";
+import "kessel/inventory/v1beta1/authz/common.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/authz";
+option java_multiple_files = true;
+option java_package = "org.project_kessel.api.inventory.v1beta1.authz";
+
+service KesselCheckService {
+	// Checks for the existence of a single Relationship 
+	// (a Relation between a Resource and a Subject or Subject Set).
+	rpc CheckForView (CheckForViewRequest) returns (CheckForViewResponse) {
+		option (google.api.http) = {
+			post: "/api/inventory/v1beta1/authz/check"
+			body: "*"
+		};
+	};
+	
+	rpc CheckForUpdate (CheckForUpdateRequest) returns (CheckForUpdateResponse) {
+		option (google.api.http) = {
+			post: "/api/inventory/v1beta1/authz/checkforupdate"
+			body: "*"
+		};
+	};
+
+	rpc CheckForCreate (CheckForCreateRequest) returns (CheckForCreateResponse) {
+		option (google.api.http) = {
+			post: "/api/inventory/v1beta1/authz/checkforcreate"
+			body: "*"
+		};
+	};
+}
+
+message CheckForViewRequest {
+	// Required parameters (from an authz perspective)
+	// - resource type and id
+	// - permission (cannot be derived from the type as a type may have multiple 'read' permissions. Ex: https://github.com/RedHatInsights/rbac-config/blob/master/configs/prod/schemas/src/notifications.ksl#L31)
+	// - user (possibly derived from an identity token)
+	ObjectReference parent = 1 [(buf.validate.field).required = true];
+	string relation = 2 [(buf.validate.field).string.min_len = 1];
+	SubjectReference subject = 3 [(buf.validate.field).required = true];
+	// Consistency consistency = 4;
+}
+
+message CheckForViewResponse {
+	enum Allowed {
+		ALLOWED_UNSPECIFIED = 0;
+		ALLOWED_TRUE = 1;
+		ALLOWED_FALSE = 2;
+		// e.g.  ALLOWED_CONDITIONAL = 3;
+	}
+	Allowed allowed = 1;
+}
+
+message CheckForUpdateRequest { // fully consistent
+	// Required parameters (from an authz perspective)
+	// - resource type and id
+	// - permission (cannot be derived from type as types may have multiple edit permissions Ex: https://github.com/RedHatInsights/rbac-config/blob/master/configs/prod/schemas/src/notifications.ksl#L37)
+	// - user (possibly derived from an identity token)
+	ObjectReference parent = 1 [(buf.validate.field).required = true];
+	string relation = 2 [(buf.validate.field).string.min_len = 1];
+	SubjectReference subject = 3 [(buf.validate.field).required = true];
+}
+
+message CheckForUpdateResponse {
+	enum Allowed {
+		ALLOWED_UNSPECIFIED = 0;
+		ALLOWED_TRUE = 1;
+		ALLOWED_FALSE = 2;
+		// e.g.  ALLOWED_CONDITIONAL = 3;
+	}
+	Allowed allowed = 1;
+}
+
+// may make sense to get away with just checkforview and checkforupdate.
+message CheckForCreateRequest { // fully consistent & just create permission.
+	// Required parameters (from an authz perspective)
+	// 	- resource type (located in Metadata, could be discrete argument)
+	// 		Alternatively: the workspace-level 'create' permission for the resource type. Note: this parameter is not normally part of the CreateResource call (but may need to be if this is rolled into CreateResource and it cannot be derived from the resource type)
+	// 	- parent object type and id (typically a workspace, located in Metadata, could be discrete argument)
+	// Note: may be part of CreateResource or separate depending on consistency algorithm requirements
+	ObjectReference parent = 1 [(buf.validate.field).required = true];
+	string create_permission = 2 [(buf.validate.field).string.min_len = 1];
+	SubjectReference subject = 3 [(buf.validate.field).required = true];
+}
+
+message CheckForCreateResponse { // same response, diff implementation.
+	enum Allowed {
+		ALLOWED_UNSPECIFIED = 0;
+		ALLOWED_TRUE = 1;
+		ALLOWED_FALSE = 2;
+		// e.g.  ALLOWED_CONDITIONAL = 3;
+	}
+	Allowed allowed = 1;
+}

--- a/src/main/proto/kessel/inventory/v1beta1/authz/check.proto
+++ b/src/main/proto/kessel/inventory/v1beta1/authz/check.proto
@@ -13,7 +13,7 @@ option java_package = "org.project_kessel.api.inventory.v1beta1.authz";
 service KesselCheckService {
 	// Checks for the existence of a single Relationship 
 	// (a Relation between a Resource and a Subject or Subject Set).
-	rpc CheckForView (CheckForViewRequest) returns (CheckForViewResponse) {
+	rpc Check (CheckRequest) returns (CheckResponse) {
 		option (google.api.http) = {
 			post: "/api/inventory/v1beta1/authz/check"
 			body: "*"
@@ -26,16 +26,9 @@ service KesselCheckService {
 			body: "*"
 		};
 	};
-
-	rpc CheckForCreate (CheckForCreateRequest) returns (CheckForCreateResponse) {
-		option (google.api.http) = {
-			post: "/api/inventory/v1beta1/authz/checkforcreate"
-			body: "*"
-		};
-	};
 }
 
-message CheckForViewRequest {
+message CheckRequest {
 	// Required parameters (from an authz perspective)
 	// - resource type and id
 	// - permission (cannot be derived from the type as a type may have multiple 'read' permissions. Ex: https://github.com/RedHatInsights/rbac-config/blob/master/configs/prod/schemas/src/notifications.ksl#L31)
@@ -46,7 +39,7 @@ message CheckForViewRequest {
 	// Consistency consistency = 4;
 }
 
-message CheckForViewResponse {
+message CheckResponse {
 	enum Allowed {
 		ALLOWED_UNSPECIFIED = 0;
 		ALLOWED_TRUE = 1;
@@ -67,28 +60,6 @@ message CheckForUpdateRequest { // fully consistent
 }
 
 message CheckForUpdateResponse {
-	enum Allowed {
-		ALLOWED_UNSPECIFIED = 0;
-		ALLOWED_TRUE = 1;
-		ALLOWED_FALSE = 2;
-		// e.g.  ALLOWED_CONDITIONAL = 3;
-	}
-	Allowed allowed = 1;
-}
-
-// may make sense to get away with just checkforview and checkforupdate.
-message CheckForCreateRequest { // fully consistent & just create permission.
-	// Required parameters (from an authz perspective)
-	// 	- resource type (located in Metadata, could be discrete argument)
-	// 		Alternatively: the workspace-level 'create' permission for the resource type. Note: this parameter is not normally part of the CreateResource call (but may need to be if this is rolled into CreateResource and it cannot be derived from the resource type)
-	// 	- parent object type and id (typically a workspace, located in Metadata, could be discrete argument)
-	// Note: may be part of CreateResource or separate depending on consistency algorithm requirements
-	ObjectReference parent = 1 [(buf.validate.field).required = true];
-	string create_permission = 2 [(buf.validate.field).string.min_len = 1];
-	SubjectReference subject = 3 [(buf.validate.field).required = true];
-}
-
-message CheckForCreateResponse { // same response, diff implementation.
 	enum Allowed {
 		ALLOWED_UNSPECIFIED = 0;
 		ALLOWED_TRUE = 1;

--- a/src/main/proto/kessel/inventory/v1beta1/authz/common.proto
+++ b/src/main/proto/kessel/inventory/v1beta1/authz/common.proto
@@ -1,0 +1,72 @@
+syntax = "proto3";
+
+package kessel.inventory.v1beta1.authz;
+
+import "buf/validate/validate.proto";
+
+option go_package = "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta1/authz";
+option java_multiple_files = true;
+option java_package = "org.project_kessel.api.inventory.v1beta1.authz";
+
+// A _Relationship_ is the realization of a _Relation_ (a string) 
+// between a _Resource_ and a _Subject_ or a _Subject Set_ (known as a Userset in Zanzibar).
+//
+// All Relationships are object-object relations.
+// "Resource" and "Subject" are relative terms which define the direction of a Relation.
+// That is, Relations are unidirectional.
+// If you reverse the Subject and Resource, it is a different Relation and a different Relationship.
+// Conventionally, we generally refer to the Resource first, then Subject,
+// following the direction of typical graph traversal (Resource to Subject).
+message Relationship {
+	ObjectReference resource = 1 [(buf.validate.field).required = true]; 
+	string relation = 2 [(buf.validate.field).string.min_len = 1];
+	SubjectReference subject = 3 [(buf.validate.field).required = true];
+}
+
+// A reference to a Subject or, if a `relation` is provided, a Subject Set.
+message SubjectReference {
+	// An optional relation which points to a set of Subjects instead of the single Subject.
+	// e.g. "members" or "owners" of a group identified in `subject`.
+	optional string relation = 1;
+	ObjectReference subject = 2 [(buf.validate.field).required = true];
+}
+
+message RequestPagination {
+	uint32 limit = 1 [(buf.validate.field).uint32 = {gt: 0}];
+	optional string continuation_token = 2;
+}
+
+message ResponsePagination {
+	string continuation_token = 1;
+}
+
+message ObjectReference {
+	ObjectType type = 1 [(buf.validate.field).required = true];
+	string id = 2 [(buf.validate.field).string.min_len = 1];
+}
+
+message ObjectType {
+	string namespace = 1 [(buf.validate.field).string.min_len = 1];
+	string name = 2 [(buf.validate.field).string.min_len = 1];
+}
+
+// Defines how a request is handled by the service.
+message Consistency {
+	oneof requirement {
+		option (buf.validate.oneof).required = true;
+
+		// The service selects the fastest snapshot available.
+		// *Must* be set true if used.
+		bool minimize_latency = 1 [(buf.validate.field).bool.const = true];
+		
+		// All data used in the API call must be *at least as fresh* 
+		// as found in the ConsistencyToken. More recent data might be used
+		// if available or faster.
+		ConsistencyToken at_least_as_fresh = 2;
+	}
+}
+
+// The ConsistencyToken is used to provide consistency between write and read requests.
+message ConsistencyToken {
+	string token = 1 [(buf.validate.field).string.min_len = 1];
+}

--- a/src/main/proto/kessel/inventory/v1beta1/resources/notifications_integrations_service.proto
+++ b/src/main/proto/kessel/inventory/v1beta1/resources/notifications_integrations_service.proto
@@ -5,6 +5,7 @@ package kessel.inventory.v1beta1.resources;
 import "google/api/annotations.proto";
 import "buf/validate/validate.proto";
 
+import "kessel/inventory/v1beta1/authz/common.proto";
 import "kessel/inventory/v1beta1/resources/notifications_integration.proto";
 import "kessel/inventory/v1beta1/resources/reporter_data.proto";
 
@@ -37,6 +38,21 @@ message DeleteNotificationsIntegrationRequest {
 
 message DeleteNotificationsIntegrationResponse {}
 
+message ListNotificationsIntegrationsRequest {
+	// resource type and parent relationship
+	// permission (unless some variation of 'this is the permission used for visibility' can be baked into the schema- this is different from the permission parameter in CheckForView because only checks for actual visibility likely matter here)
+	// parent resource type and id
+
+  authz.ObjectType resource_type = 1 [(buf.validate.field).required = true];
+	string relation = 2 [(buf.validate.field).string.min_len = 1];
+	authz.SubjectReference subject = 3 [(buf.validate.field).required = true];
+  authz.ObjectReference parent = 4 [(buf.validate.field).required = true]; 
+}
+
+message ListNotificationsIntegrationsResponse {
+  NotificationsIntegration integrations = 1;
+}
+
 service KesselNotificationsIntegrationService {
   rpc CreateNotificationsIntegration(CreateNotificationsIntegrationRequest) returns (CreateNotificationsIntegrationResponse) {
     option (google.api.http) = {
@@ -55,6 +71,13 @@ service KesselNotificationsIntegrationService {
   rpc DeleteNotificationsIntegration(DeleteNotificationsIntegrationRequest) returns (DeleteNotificationsIntegrationResponse) {
     option (google.api.http) = {
       delete : "/api/inventory/v1beta1/resources/notifications-integrations"
+      body : "*"
+    };
+  };
+  
+  rpc ListNotificationsIntegrations(ListNotificationsIntegrationsRequest) returns (stream ListNotificationsIntegrationsResponse) {
+    option (google.api.http) = {
+      get : "/api/inventory/v1beta1/resources/notifications-integrations"
       body : "*"
     };
   };

--- a/src/main/proto/kessel/inventory/v1beta1/resources/notifications_integrations_service.proto
+++ b/src/main/proto/kessel/inventory/v1beta1/resources/notifications_integrations_service.proto
@@ -44,8 +44,8 @@ message ListNotificationsIntegrationsRequest {
 	// parent resource type and id
 
   authz.ObjectType resource_type = 1 [(buf.validate.field).required = true];
-	string relation = 2 [(buf.validate.field).string.min_len = 1];
-	authz.SubjectReference subject = 3 [(buf.validate.field).required = true];
+  string relation = 2 [(buf.validate.field).string.min_len = 1];
+  authz.SubjectReference subject = 3 [(buf.validate.field).required = true];
   authz.ObjectReference parent = 4 [(buf.validate.field).required = true]; 
 }
 

--- a/src/main/proto/kessel/inventory/v1beta1/resources/notifications_integrations_service.proto
+++ b/src/main/proto/kessel/inventory/v1beta1/resources/notifications_integrations_service.proto
@@ -78,7 +78,6 @@ service KesselNotificationsIntegrationService {
   rpc ListNotificationsIntegrations(ListNotificationsIntegrationsRequest) returns (stream ListNotificationsIntegrationsResponse) {
     option (google.api.http) = {
       get : "/api/inventory/v1beta1/resources/notifications-integrations"
-      body : "*"
     };
   };
 }


### PR DESCRIPTION
Adds RPCs required to utilize: https://github.com/project-kessel/inventory-api/pull/373

Copies over protos for Check rpcs and ListNotificationsIntegrations rpc.

- Adds ability to get kesselCheckClient
- Adds references to utilize new APIs `Check`, `CheckForUpdate` and `ListNotificationsIntegrations`
- Updates workflow to copy changes from `api/kessel/inventory/v1beta1/authz` directory to get any future updates to check protos.

https://issues.redhat.com/browse/RHCLOUD-38917
