### PR TITLE
Update sync proto workflow with v1beta2 changes

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -23,6 +23,7 @@ jobs:
           cp -r inventory-api/api/kessel/inventory/v1beta1/relationships/*.proto src/main/proto/kessel/inventory/v1beta1/
           cp -r inventory-api/api/kessel/inventory/v1beta1/resources/*.proto src/main/proto/kessel/inventory/v1beta1/
           cp -r inventory-api/api/kessel/inventory/v1beta1/authz/*.proto src/main/proto/kessel/inventory/v1beta1/
+          cp -r inventory-api/api/kessel/inventory/v1beta2/*.proto src/main/proto/kessel/inventory/v1beta2/
           rm -rf inventory-api/
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
Updating proto sync job to update protos with updated v1beta2 changes.

Apart of https://issues.redhat.com/browse/RHCLOUD-39359

## Summary by Sourcery

CI:
- Added step to copy v1beta2 inventory API proto files to the project