### PR TITLE
RHCLOUD-39359 - Update client with v1beta2 changes

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Copy proto files
         run: |
           cp -r inventory-api/api/kessel/inventory/v1/*.proto src/main/proto/kessel/inventory/v1/
-          cp -r inventory-api/api/kessel/inventory/v1beta1/relationships/*.proto src/main/proto/kessel/inventory/v1beta1/
-          cp -r inventory-api/api/kessel/inventory/v1beta1/resources/*.proto src/main/proto/kessel/inventory/v1beta1/
-          cp -r inventory-api/api/kessel/inventory/v1beta1/authz/*.proto src/main/proto/kessel/inventory/v1beta1/
+          cp -r inventory-api/api/kessel/inventory/v1beta1/relationships/*.proto src/main/proto/kessel/inventory/v1beta1/relationships/
+          cp -r inventory-api/api/kessel/inventory/v1beta1/resources/*.proto src/main/proto/kessel/inventory/v1beta1/resources/
+          cp -r inventory-api/api/kessel/inventory/v1beta1/authz/*.proto src/main/proto/kessel/inventory/v1beta1/authz/
           cp -r inventory-api/api/kessel/inventory/v1beta2/*.proto src/main/proto/kessel/inventory/v1beta2/
           rm -rf inventory-api/
       - name: Create Pull Request

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.project-kessel</groupId>
             <artifactId>common-client-java</artifactId>
-            <version>0.3</version>
+            <version>0.4</version>
         </dependency>
         <dependency>
             <groupId>build.buf</groupId>

--- a/src/main/java/org/project_kessel/inventory/client/InventoryGrpcClientsManager.java
+++ b/src/main/java/org/project_kessel/inventory/client/InventoryGrpcClientsManager.java
@@ -66,4 +66,8 @@ public class InventoryGrpcClientsManager extends KesselClientsManager {
     public KesselCheckClient getKesselCheckClient() {
         return new KesselCheckClient(channel);
     }
+
+    public KesselInventoryClient getKesselInventoryClient() {
+        return new KesselInventoryClient(channel);
+    }
 }

--- a/src/main/java/org/project_kessel/inventory/client/KesselCheckClient.java
+++ b/src/main/java/org/project_kessel/inventory/client/KesselCheckClient.java
@@ -15,7 +15,7 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 
 public class KesselCheckClient extends KesselClient<KesselCheckServiceGrpc.KesselCheckServiceStub, KesselCheckServiceGrpc.KesselCheckServiceBlockingStub> {
-    private static final Logger logger = Logger.getLogger(RhelHostClient.class.getName());
+    private static final Logger logger = Logger.getLogger(KesselCheckClient.class.getName());
 
     KesselCheckClient(Channel channel) {
         super(KesselCheckServiceGrpc.newStub(channel), KesselCheckServiceGrpc.newBlockingStub(channel));

--- a/src/main/java/org/project_kessel/inventory/client/KesselInventoryClient.java
+++ b/src/main/java/org/project_kessel/inventory/client/KesselInventoryClient.java
@@ -1,0 +1,192 @@
+package org.project_kessel.inventory.client;
+
+import java.util.logging.Logger;
+
+import org.project_kessel.api.inventory.v1beta2.CheckForUpdateRequest;
+import org.project_kessel.api.inventory.v1beta2.CheckForUpdateResponse;
+import org.project_kessel.api.inventory.v1beta2.CheckRequest;
+import org.project_kessel.api.inventory.v1beta2.CheckResponse;
+import org.project_kessel.api.inventory.v1beta2.DeleteResourceRequest;
+import org.project_kessel.api.inventory.v1beta2.DeleteResourceResponse;
+import org.project_kessel.api.inventory.v1beta2.KesselInventoryServiceGrpc;
+import org.project_kessel.api.inventory.v1beta2.ReportResourceRequest;
+import org.project_kessel.api.inventory.v1beta2.ReportResourceResponse;
+import org.project_kessel.api.inventory.v1beta2.StreamedListObjectsRequest;
+import org.project_kessel.api.inventory.v1beta2.StreamedListObjectsResponse;
+import org.project_kessel.clients.KesselClient;
+
+import java.util.Iterator;
+import io.grpc.Channel;
+import io.grpc.stub.StreamObserver;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
+
+
+public class KesselInventoryClient extends KesselClient<KesselInventoryServiceGrpc.KesselInventoryServiceStub, KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub> {
+    private static final Logger logger = Logger.getLogger(KesselInventoryClient.class.getName());
+
+    KesselInventoryClient(Channel channel) {
+        super(KesselInventoryServiceGrpc.newStub(channel), KesselInventoryServiceGrpc.newBlockingStub(channel));
+    }
+
+    public CheckResponse Check(CheckRequest request) {
+        return blockingStub.check(request);
+    } 
+
+    public void Check(CheckRequest request, StreamObserver<CheckResponse> responObserver) {
+        asyncStub.check(request, responObserver);
+    }
+
+    public Uni<CheckResponse> CheckUni(CheckRequest request) {
+        final UnicastProcessor<CheckResponse> responseProcessor = UnicastProcessor.create();
+        var streamObserver = new StreamObserver<CheckResponse>() {
+            @Override
+            public void onNext(CheckResponse response) {
+                responseProcessor.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                responseProcessor.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                responseProcessor.onComplete();
+            }
+        };
+        var uni = Uni.createFrom().publisher(responseProcessor);
+        Check(request, streamObserver);
+        return uni;
+    }
+
+    public CheckForUpdateResponse CheckForUpdate(CheckForUpdateRequest request) {
+        return blockingStub.checkForUpdate(request);
+    }
+
+    public void CheckForUpdate(CheckForUpdateRequest request, StreamObserver<CheckForUpdateResponse> responObserver) {
+        asyncStub.checkForUpdate(request, responObserver);
+    }
+
+    public Uni<CheckForUpdateResponse> CheckForUpdateUni(CheckForUpdateRequest request) {
+        final UnicastProcessor<CheckForUpdateResponse> responseProcessor = UnicastProcessor.create();
+        var streamObserver = new StreamObserver<CheckForUpdateResponse>() {
+            @Override
+            public void onNext(CheckForUpdateResponse response) {
+                responseProcessor.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                responseProcessor.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                responseProcessor.onComplete();
+            }
+        };
+        var uni = Uni.createFrom().publisher(responseProcessor);
+        CheckForUpdate(request, streamObserver);
+        return uni;
+    }
+
+    
+    public ReportResourceResponse ReportResource(ReportResourceRequest request) {
+        return blockingStub.reportResource(request);
+    }
+    
+    public void ReportResource(ReportResourceRequest request, StreamObserver<ReportResourceResponse> responObserver) {
+        asyncStub.reportResource(request, responObserver);
+    }
+    
+    public Uni<ReportResourceResponse> ReportResourceUni(ReportResourceRequest request) {
+        final UnicastProcessor<ReportResourceResponse> responseProcessor = UnicastProcessor.create();
+        var streamObserver = new StreamObserver<ReportResourceResponse>() {
+            @Override
+            public void onNext(ReportResourceResponse response) {
+                responseProcessor.onNext(response);
+            }
+            
+            @Override
+            public void onError(Throwable t) {
+                responseProcessor.onError(t);
+            }
+            
+            @Override
+            public void onCompleted() {
+                responseProcessor.onComplete();
+            }
+        };
+        var uni = Uni.createFrom().publisher(responseProcessor);
+        ReportResource(request, streamObserver);
+        return uni;
+    }
+    
+    public DeleteResourceResponse DeleteResource(DeleteResourceRequest request) {
+        return blockingStub.deleteResource(request);
+    }
+
+    public void DeleteResource(DeleteResourceRequest request, StreamObserver<DeleteResourceResponse> responObserver) {
+        asyncStub.deleteResource(request, responObserver);
+    }
+
+    public Uni<DeleteResourceResponse> DeleteResourceUni(DeleteResourceRequest request) {
+        final UnicastProcessor<DeleteResourceResponse> responseProcessor = UnicastProcessor.create();
+        var streamObserver = new StreamObserver<DeleteResourceResponse>() {
+            @Override
+            public void onNext(DeleteResourceResponse response) {
+                responseProcessor.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                responseProcessor.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                responseProcessor.onComplete();
+            }
+        };
+        var uni = Uni.createFrom().publisher(responseProcessor);
+        DeleteResource(request, streamObserver);
+        return uni;
+    }
+
+    public void streamedListObjects(StreamedListObjectsRequest request,
+                                StreamObserver<StreamedListObjectsResponse> responseObserver) {
+        asyncStub.streamedListObjects(request, responseObserver);
+    }
+
+    public Iterator<StreamedListObjectsResponse> streamedListObjects(StreamedListObjectsRequest request) {
+        return blockingStub.streamedListObjects(request);
+    }
+
+    public Multi<StreamedListObjectsResponse> streamedListObjectsMulti(StreamedListObjectsRequest request) {
+        final UnicastProcessor<StreamedListObjectsResponse> responseProcessor = UnicastProcessor.create();
+
+        var streamObserver = new StreamObserver<StreamedListObjectsResponse>() {
+            @Override
+            public void onNext(StreamedListObjectsResponse response) {
+                responseProcessor.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                responseProcessor.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                responseProcessor.onComplete();
+            }
+        };
+
+        var multi = Multi.createFrom().publisher(responseProcessor);
+        streamedListObjects(request, streamObserver);
+
+        return multi;
+    }
+}

--- a/src/main/java/org/project_kessel/inventory/client/KesselInventoryClient.java
+++ b/src/main/java/org/project_kessel/inventory/client/KesselInventoryClient.java
@@ -73,7 +73,23 @@ public class KesselInventoryClient extends KesselClient<KesselInventoryServiceGr
     public Iterator<StreamedListObjectsResponse> streamedListObjects(StreamedListObjectsRequest request) {
         return blockingStub.streamedListObjects(request);
     }
+
+    public Uni<CheckResponse> CheckUni(CheckRequest request) {
+        return toUni(observer -> Check(request, observer));
+    }
     
+    public Uni<CheckForUpdateResponse> CheckForUpdateUni(CheckForUpdateRequest request) {
+        return toUni(observer -> CheckForUpdate(request, observer));
+    }
+    
+    public Uni<ReportResourceResponse> ReportResourceUni(ReportResourceRequest request) {
+        return toUni(observer -> ReportResource(request, observer));
+    }
+    
+    public Uni<DeleteResourceResponse> DeleteResourceUni(DeleteResourceRequest request) {
+        return toUni(observer -> DeleteResource(request, observer));
+    }
+
     private <T> Uni<T> toUni(Consumer<StreamObserver<T>> grpcCall) {
         final UnicastProcessor<T> processor = UnicastProcessor.create();
         StreamObserver<T> observer = new StreamObserver<T>() {

--- a/src/main/java/org/project_kessel/inventory/client/KesselInventoryClient.java
+++ b/src/main/java/org/project_kessel/inventory/client/KesselInventoryClient.java
@@ -44,8 +44,8 @@ public class KesselInventoryClient extends KesselClient<KesselInventoryServiceGr
         return blockingStub.checkForUpdate(request);
     }
     
-    public void CheckForUpdate(CheckForUpdateRequest request, StreamObserver<CheckForUpdateResponse> responObserver) {
-        asyncStub.checkForUpdate(request, responObserver);
+    public void CheckForUpdate(CheckForUpdateRequest request, StreamObserver<CheckForUpdateResponse> responseObserver) {
+        asyncStub.checkForUpdate(request, responseObserver);
     }
     
     
@@ -53,16 +53,16 @@ public class KesselInventoryClient extends KesselClient<KesselInventoryServiceGr
         return blockingStub.reportResource(request);
     }
     
-    public void ReportResource(ReportResourceRequest request, StreamObserver<ReportResourceResponse> responObserver) {
-        asyncStub.reportResource(request, responObserver);
+    public void ReportResource(ReportResourceRequest request, StreamObserver<ReportResourceResponse> responseObserver) {
+        asyncStub.reportResource(request, responseObserver);
     }
     
     public DeleteResourceResponse DeleteResource(DeleteResourceRequest request) {
         return blockingStub.deleteResource(request);
     }
     
-    public void DeleteResource(DeleteResourceRequest request, StreamObserver<DeleteResourceResponse> responObserver) {
-        asyncStub.deleteResource(request, responObserver);
+    public void DeleteResource(DeleteResourceRequest request, StreamObserver<DeleteResourceResponse> responseObserver) {
+        asyncStub.deleteResource(request, responseObserver);
     }
     
     public void streamedListObjects(StreamedListObjectsRequest request,

--- a/src/main/java/org/project_kessel/inventory/client/NotificationsIntegrationClient.java
+++ b/src/main/java/org/project_kessel/inventory/client/NotificationsIntegrationClient.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
 
 public class NotificationsIntegrationClient extends KesselClient<KesselNotificationsIntegrationServiceGrpc.KesselNotificationsIntegrationServiceStub, KesselNotificationsIntegrationServiceGrpc.KesselNotificationsIntegrationServiceBlockingStub>{
 
-    private static final Logger logger = Logger.getLogger(RhelHostClient.class.getName());
+    private static final Logger logger = Logger.getLogger(NotificationsIntegrationClient.class.getName());
 
     NotificationsIntegrationClient(Channel channel) {
         super(KesselNotificationsIntegrationServiceGrpc.newStub(channel), KesselNotificationsIntegrationServiceGrpc.newBlockingStub(channel));

--- a/src/main/java/org/project_kessel/inventory/example/Caller.java
+++ b/src/main/java/org/project_kessel/inventory/example/Caller.java
@@ -8,11 +8,21 @@ import org.project_kessel.api.inventory.v1beta2.CheckForUpdateRequest;
 import org.project_kessel.api.inventory.v1beta2.CheckForUpdateResponse;
 import org.project_kessel.api.inventory.v1beta2.CheckRequest;
 import org.project_kessel.api.inventory.v1beta2.CheckResponse;
+import org.project_kessel.api.inventory.v1beta2.DeleteResourceRequest;
+import org.project_kessel.api.inventory.v1beta2.DeleteResourceResponse;
+import org.project_kessel.api.inventory.v1beta2.ReportResourceRequest;
+import org.project_kessel.api.inventory.v1beta2.ReportResourceResponse;
 import org.project_kessel.api.inventory.v1beta2.ReporterReference;
+import org.project_kessel.api.inventory.v1beta2.RepresentationMetadata;
 import org.project_kessel.api.inventory.v1beta2.ResourceReference;
+import org.project_kessel.api.inventory.v1beta2.ResourceRepresentations;
 import org.project_kessel.api.inventory.v1beta2.SubjectReference;
+import org.project_kessel.api.inventory.v1beta2.WriteVisibility;
 import org.project_kessel.inventory.client.InventoryGrpcClientsManager;
 import org.project_kessel.inventory.client.KesselInventoryClient;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
 
 import io.grpc.stub.StreamObserver;
 import io.smallrye.mutiny.Uni;
@@ -30,6 +40,8 @@ public class Caller {
 
         checkExample();
         checkForUpdateExample();
+        reportResourceExample();
+        deleteResourceExample();
     }
 
     public static void checkExample() {
@@ -222,5 +234,64 @@ public class Caller {
                     }
                 })
                 .await().indefinitely();
+    }
+
+    public static void reportResourceExample() {
+        var reportResourceRequest = ReportResourceRequest.newBuilder()
+                .setWriteVisibility(WriteVisibility.IMMEDIATE)
+                .setType("host")
+                .setReporterType("hbi")
+                .setReporterInstanceId("3088be62-1c60-4884-b133-9200542d0b3f")
+                .setRepresentations(ResourceRepresentations.newBuilder()
+                        .setReporter(Struct.newBuilder()
+                                .putFields("satellite_id",
+                                        Value.newBuilder().setStringValue("2c4196f1-0371-4f4c-8913-e113cfaa6e67")
+                                                .build())
+                                .putFields("sub_manager_id",
+                                        Value.newBuilder().setStringValue("af94f92b-0b65-4cac-b449-6b77e665a08f")
+                                                .build())
+                                .putFields("insights_inventory_id",
+                                        Value.newBuilder().setStringValue("05707922-7b0a-4fe6-982d-6adbc7695b8f")
+                                                .build())
+                                .putFields("ansible_host", Value.newBuilder().setStringValue("host-1").build()))
+                        .setMetadata(RepresentationMetadata.newBuilder()
+                                .setLocalResourceId("dd1b73b9-3e33-4264-968c-e3ce55b9afec")
+                                .setApiHref("https://apiHref.com/")
+                                .setConsoleHref("https://www.console.com/")
+                                .setReporterVersion("2.7.16"))
+                        .setCommon(Struct.newBuilder()
+                                .putFields("workspace_id",
+                                        Value.newBuilder().setStringValue("a64d17d0-aec3-410a-acd0-e0b85b22c076")
+                                                .build())
+                                .build())
+                        .build())
+                .build();
+
+        // Can only create the same object once.
+        var reportResourceResponse = inventoryClient.ReportResource(reportResourceRequest);
+        var permitted = reportResourceResponse == ReportResourceResponse.getDefaultInstance();
+
+        if (permitted) {
+            System.out.println("Reported.");
+        }
+    }
+
+    public static void deleteResourceExample() {
+        var deleteResourceRequest = DeleteResourceRequest.newBuilder()
+            .setReference(ResourceReference.newBuilder()
+            .setResourceId("dd1b73b9-3e33-4264-968c-e3ce55b9afec")
+            .setResourceType("host")
+            .setReporter(ReporterReference.newBuilder()
+                .setType("HBI"))
+                .build())
+            .build();
+        
+        // Can only delete the same object once.
+        var deleteResourceResponse = inventoryClient.DeleteResource(deleteResourceRequest);
+        var permitted = deleteResourceResponse == DeleteResourceResponse.getDefaultInstance();
+
+        if (permitted) {
+            System.out.println("Deleted.");
+        }
     }
 }

--- a/src/main/java/org/project_kessel/inventory/example/Caller.java
+++ b/src/main/java/org/project_kessel/inventory/example/Caller.java
@@ -1,16 +1,226 @@
 package org.project_kessel.inventory.example;
 
+import java.util.concurrent.CountDownLatch;
+
 import org.project_kessel.api.inventory.v1.GetLivezRequest;
+import org.project_kessel.api.inventory.v1beta2.Allowed;
+import org.project_kessel.api.inventory.v1beta2.CheckForUpdateRequest;
+import org.project_kessel.api.inventory.v1beta2.CheckForUpdateResponse;
+import org.project_kessel.api.inventory.v1beta2.CheckRequest;
+import org.project_kessel.api.inventory.v1beta2.CheckResponse;
+import org.project_kessel.api.inventory.v1beta2.ReporterReference;
+import org.project_kessel.api.inventory.v1beta2.ResourceReference;
+import org.project_kessel.api.inventory.v1beta2.SubjectReference;
 import org.project_kessel.inventory.client.InventoryGrpcClientsManager;
+import org.project_kessel.inventory.client.KesselInventoryClient;
+
+import io.grpc.stub.StreamObserver;
+import io.smallrye.mutiny.Uni;
 
 public class Caller {
 
-    public static void main(String[] argv) {
-        var url = "localhost:9081";
-        var clientsManager = InventoryGrpcClientsManager.forInsecureClients(url);
-          var healthClient = clientsManager.getHealthClient();
-          var response = healthClient.getLivez(GetLivezRequest.newBuilder().build());
-          System.out.println(response);
+    static String url = "localhost:9081";
+    static InventoryGrpcClientsManager clientsManager = InventoryGrpcClientsManager.forInsecureClients(url);
+    static KesselInventoryClient inventoryClient = clientsManager.getKesselInventoryClient();
 
+    public static void main(String[] argv) {
+        var healthClient = clientsManager.getHealthClient();
+        var response = healthClient.getLivez(GetLivezRequest.newBuilder().build());
+        System.out.println(response);
+
+        checkExample();
+        checkForUpdateExample();
+    }
+
+    public static void checkExample() {
+        var checkRequest = CheckRequest.newBuilder()
+                .setSubject(SubjectReference.newBuilder().setResource(ResourceReference.newBuilder()
+                        .setResourceId("bob")
+                        .setResourceType("principal")
+                        .setReporter(ReporterReference.newBuilder()
+                                .setType("rbac")
+                                .build())
+                        .build())
+                        .build())
+                .setRelation("member")
+                .setObject(ResourceReference.newBuilder()
+                        .setResourceId("bob_club")
+                        .setResourceType("group")
+                        .setReporter(ReporterReference.newBuilder()
+                                .setType("rbac")
+                                .build())
+                        .build())
+                .build();
+
+        var checkResponse = inventoryClient.Check(checkRequest);
+        var permitted = checkResponse.getAllowed() == Allowed.ALLOWED_TRUE;
+
+        if (permitted) {
+            System.out.println("Blocking: Permitted");
+        } else {
+            System.out.println("Blocking: Denied");
+        }
+
+        /*
+         * Non-blocking
+         */
+
+        final CountDownLatch conditionLatch = new CountDownLatch(1);
+        var streamObserver = new StreamObserver<CheckResponse>() {
+            @Override
+            public void onNext(CheckResponse response) {
+                /*
+                 * Because we don't return a stream, but a response object with all the
+                 * relationships inside,
+                 * we get no benefit from an async/non-blocking call right now. It all returns
+                 * at once.
+                 */
+                var permitted = response.getAllowed() == Allowed.ALLOWED_TRUE;
+
+                if (permitted) {
+                    System.out.println("Non-blocking: Permitted");
+                } else {
+                    System.out.println("Non-blocking: Denied");
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                // TODO:
+            }
+
+            @Override
+            public void onCompleted() {
+                conditionLatch.countDown();
+            }
+        };
+
+        inventoryClient.Check(checkRequest, streamObserver);
+
+        /*
+         * Use a passed-in countdownlatch to wait for the result async on the main
+         * thread
+         */
+        try {
+            conditionLatch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        /*
+         * Non-blocking reactive style
+         */
+
+        Uni<CheckResponse> uni = inventoryClient.CheckUni(checkRequest);
+
+        /*
+         * Pattern where we may want collect all the responses, but still operate on
+         * each as it comes in.
+         */
+        CheckResponse cr = uni.onItem()
+                .invoke(() -> {
+                    if (permitted) {
+                        System.out.println("Reactive non-blocking: Permitted");
+                    } else {
+                        System.out.println("Reactive non-blocking: Denied");
+                    }
+                })
+                .await().indefinitely();
+    }
+
+    public static void checkForUpdateExample() {
+        var checkRequest = CheckForUpdateRequest.newBuilder()
+                .setSubject(SubjectReference.newBuilder().setResource(ResourceReference.newBuilder()
+                        .setResourceId("bob")
+                        .setResourceType("principal")
+                        .setReporter(ReporterReference.newBuilder()
+                                .setType("rbac")
+                                .build())
+                        .build())
+                        .build())
+                .setRelation("member")
+                .setObject(ResourceReference.newBuilder()
+                        .setResourceId("bob_club")
+                        .setResourceType("group")
+                        .setReporter(ReporterReference.newBuilder()
+                                .setType("rbac")
+                                .build())
+                        .build())
+                .build();
+
+        var checkResponse = inventoryClient.CheckForUpdate(checkRequest);
+        var permitted = checkResponse.getAllowed() == Allowed.ALLOWED_TRUE;
+
+        if (permitted) {
+            System.out.println("Blocking: Permitted");
+        } else {
+            System.out.println("Blocking: Denied");
+        }
+
+        /*
+         * Non-blocking
+         */
+
+        final CountDownLatch conditionLatch = new CountDownLatch(1);
+        var streamObserver = new StreamObserver<CheckForUpdateResponse>() {
+            @Override
+            public void onNext(CheckForUpdateResponse response) {
+                /*
+                 * Because we don't return a stream, but a response object with all the
+                 * relationships inside,
+                 * we get no benefit from an async/non-blocking call right now. It all returns
+                 * at once.
+                 */
+                var permitted = response.getAllowed() == Allowed.ALLOWED_TRUE;
+
+                if (permitted) {
+                    System.out.println("Non-blocking: Permitted");
+                } else {
+                    System.out.println("Non-blocking: Denied");
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                // TODO:
+            }
+
+            @Override
+            public void onCompleted() {
+                conditionLatch.countDown();
+            }
+        };
+
+        inventoryClient.CheckForUpdate(checkRequest, streamObserver);
+
+        /*
+         * Use a passed-in countdownlatch to wait for the result async on the main
+         * thread
+         */
+        try {
+            conditionLatch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        /*
+         * Non-blocking reactive style
+         */
+
+        Uni<CheckForUpdateResponse> uni = inventoryClient.CheckForUpdateUni(checkRequest);
+
+        /*
+         * Pattern where we may want collect all the responses, but still operate on
+         * each as it comes in.
+         */
+        CheckForUpdateResponse cr = uni.onItem()
+                .invoke(() -> {
+                    if (permitted) {
+                        System.out.println("Reactive non-blocking: Permitted");
+                    } else {
+                        System.out.println("Reactive non-blocking: Denied");
+                    }
+                })
+                .await().indefinitely();
     }
 }

--- a/src/main/proto/kessel/inventory/v1beta1/relationships/k8spolicy_ispropagatedto_k8scluster_detail.proto
+++ b/src/main/proto/kessel/inventory/v1beta1/relationships/k8spolicy_ispropagatedto_k8scluster_detail.proto
@@ -21,10 +21,10 @@ message K8SPolicyIsPropagatedToK8SClusterDetail {
   }
 
   // The resource ID assigned to the resource by Kessel Asset Inventory. 
-  int64 k8s_policy_id = 225679544 [ json_name = "k8s_policy_id", (google.api.field_behavior) = OUTPUT_ONLY ];
+  string k8s_policy_id = 225679544 [ json_name = "k8s_policy_id", (google.api.field_behavior) = OUTPUT_ONLY ];
 
   // The resource ID assigned to the resource by Kessel Asset Inventory. 
-  int64 k8s_cluster_id = 240280960 [ json_name = "k8s_cluster_id", (google.api.field_behavior) = OUTPUT_ONLY ];
+  string k8s_cluster_id = 240280960 [ json_name = "k8s_cluster_id", (google.api.field_behavior) = OUTPUT_ONLY ];
 
   Status status = 355610639 [ json_name = "status",(buf.validate.field).enum = {not_in: [0], defined_only: true} ];
 }

--- a/src/main/proto/kessel/inventory/v1beta1/relationships/metadata.proto
+++ b/src/main/proto/kessel/inventory/v1beta1/relationships/metadata.proto
@@ -12,7 +12,7 @@ option java_package = "org.project_kessel.api.inventory.v1beta1.relationships";
 
 message Metadata {
   // Kessel Asset Inventory generated identifier.
-  int64 id = 3356 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  string id = 3356 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 
   // The type of Resource relationship
   string relationship_type = 251000036 

--- a/src/main/proto/kessel/inventory/v1beta1/resources/k8s_cluster_detail.proto
+++ b/src/main/proto/kessel/inventory/v1beta1/resources/k8s_cluster_detail.proto
@@ -64,6 +64,12 @@ message K8sClusterDetail {
 
   ClusterStatus cluster_status = 499346904  [  json_name = "cluster_status", (buf.validate.field).enum = {not_in: [0], defined_only: true} ];
 
+  optional string cluster_reason = 499346905 [  json_name = "cluster_reason",
+    (buf.validate.field).string.min_len = 1,
+    (buf.validate.field).string.max_len = 1024,
+    (buf.validate.field).string.pattern = "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+  ];
+
   // The version of kubernetes
   string kube_version = 395858490 [  json_name = "kube_version" ];
 
@@ -74,5 +80,5 @@ message K8sClusterDetail {
 
   CloudPlatform cloud_platform = 476768062 [  json_name = "cloud_platform", (buf.validate.field).enum = {not_in: [0], defined_only: true} ];
 
-  repeated K8sClusterDetailNodesInner nodes = 75440785 [ (buf.validate.field).repeated = {min_items: 1, items: { required: true}} ];
+  repeated K8sClusterDetailNodesInner nodes = 75440785;
 }

--- a/src/main/proto/kessel/inventory/v1beta1/resources/metadata.proto
+++ b/src/main/proto/kessel/inventory/v1beta1/resources/metadata.proto
@@ -13,7 +13,7 @@ option java_package = "org.project_kessel.api.inventory.v1beta1.resources";
 
 message Metadata {
   // Kessel Asset Inventory generated identifier.
-  int64 id = 3355 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  string id = 3355 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 
   // The type of the Resource
   string resource_type = 442752204

--- a/src/main/proto/kessel/inventory/v1beta1/resources/notifications_integrations_service.proto
+++ b/src/main/proto/kessel/inventory/v1beta1/resources/notifications_integrations_service.proto
@@ -27,7 +27,18 @@ message UpdateNotificationsIntegrationRequest {
   NotificationsIntegration integration = 1 [ (buf.validate.field).required = true ];
 }
 
+message UpdateNotificationsIntegrationsRequest {
+  // The resource to be updated will be defined by
+  // \"<reporter_data.reporter_type>:<reporter_instaance_id>:<reporter_data.local_resource_id>\"
+  // from the request body.
+  NotificationsIntegration integration = 1 [ (buf.validate.field).required = true ];
+}
+
 message UpdateNotificationsIntegrationResponse {}
+
+message UpdateNotificationsIntegrationsResponse {
+    int32 upserts_completed = 1;
+}
 
 message DeleteNotificationsIntegrationRequest {
   // The resource to be deleted will be defined by 
@@ -66,6 +77,11 @@ service KesselNotificationsIntegrationService {
       put : "/api/inventory/v1beta1/resources/notifications-integrations"
       body : "*"
     };
+  };
+
+  // deprecated Temporary streaming update endpoint
+  rpc UpdateNotificationsIntegrations(stream UpdateNotificationsIntegrationsRequest) returns (UpdateNotificationsIntegrationsResponse) {
+
   };
 
   rpc DeleteNotificationsIntegration(DeleteNotificationsIntegrationRequest) returns (DeleteNotificationsIntegrationResponse) {

--- a/src/main/proto/kessel/inventory/v1beta2/check_for_update_request.proto
+++ b/src/main/proto/kessel/inventory/v1beta2/check_for_update_request.proto
@@ -11,6 +11,10 @@ option java_multiple_files = true;
 option java_package = "org.project_kessel.api.inventory.v1beta2";
 
 message CheckForUpdateRequest {
+  // Required parameters
+  // - resource type and id
+  // - permission (cannot be derived from type as types may have multiple edit permissions Ex: https://github.com/RedHatInsights/rbac-config/blob/master/configs/prod/schemas/src/notifications.ksl#L37)
+  // - user (possibly derived from an identity token)
   ResourceReference object = 1 [(buf.validate.field).required = true];
   string relation = 2 [(buf.validate.field).string.min_len = 1];
   SubjectReference subject = 3 [(buf.validate.field).required = true];

--- a/src/main/proto/kessel/inventory/v1beta2/inventory_service.proto
+++ b/src/main/proto/kessel/inventory/v1beta2/inventory_service.proto
@@ -18,9 +18,18 @@ option go_package = "github.com/project-kessel/inventory-api/api/kessel/inventor
 option java_multiple_files = true;
 option java_package = "org.project_kessel.api.inventory.v1beta2";
 
+// KesselInventoryService provides APIs to perform relationship checks
+// and manage inventory resource lifecycles (reporting and deletion).
 service KesselInventoryService {
-  // Checks for the existence of a single Relationship
-  // (a Relation between a Resource and a Subject or Subject Set).
+  // Performs an relationship check to determine whether a subject has a specific
+  // permission or relationship on a resource.
+  //
+  // This API evaluates whether the provided subject is a member of the specified relation
+  // (e.g., "viewer", "editor", "admin") on the target object. It answers the question:
+  // "Does subject *X* have relation *Y* on object *Z*?"
+  //
+  // Common use cases include enforcing read access, conditional UI visibility,
+  // or authorization gating for downstream API calls.
   rpc Check(CheckRequest) returns (CheckResponse) {
     option (google.api.http) = {
       post: "/api/inventory/v1beta2/check"
@@ -28,6 +37,16 @@ service KesselInventoryService {
     };
   }
 
+  // Performs a strongly consistent relationship check to determine whether a subject
+  // has a specific relation to an object (representing, for example, a permission).
+  //
+  // This API answers the question:
+  // "Is subject *X* currently authorized to update or modify resource *Y*?"
+  // Unlike the basic `Check` endpoint, this method guarantees a fully up-to-date
+  // view of the relationship state (e.g., not relying on cached or eventually consistent data).
+  //
+  // It is intended to be used just prior to sensitive operation (e.g., update, delete)
+  // which depend on the current state of the relationship.
   rpc CheckForUpdate(CheckForUpdateRequest) returns (CheckForUpdateResponse) {
     option (google.api.http) = {
       post: "/api/inventory/v1beta2/checkforupdate"
@@ -35,6 +54,34 @@ service KesselInventoryService {
     };
   }
 
+  // Reports to Kessel Inventory that a Resource has been created or has been updated.
+  //
+  // Reporters can use this API to report facts about their resources in order to
+  // facilitate integration, correlation, and access control.
+  //
+  // Each call can include:
+  // - Reporter-specific attributes and relationships (`representations.reporter`)
+  // - Shared attributes and relationships common to all reporters (`representations.common`)
+  // - Identifiers and metadata that allow correlation to an existing resource
+  //
+  // Multiple reporters may report representations for the same resource.
+  // Kessel Inventory correlates these
+  // based on correlation keys provided for a given resource type
+  //
+  // All versions of your reported facts will be retained and can be queried as needed
+  //
+  // The relationships reported through this API are used to determine relationship check outcomes
+  // via the Check and CheckForUpdate APIs.
+  //
+  // Reporters are responsible for ensuring delivery guarantees and message ordering
+  // appropriate to the sensitivity and consistency needs of their use case.
+  //
+  // This API does **not** guarantee immediate read-your-writes consistency by default.
+  //  If a reporter requires newly submitted resources or relationships to be visible
+  // in subsequent checks (e.g., `Check`), the request must explicitly set
+  // `write_visibility = IMMEDIATE`.
+  //
+  //
   rpc ReportResource(ReportResourceRequest) returns (ReportResourceResponse) {
     option (google.api.http) = {
       post: "/api/inventory/v1beta2/resources"
@@ -42,6 +89,17 @@ service KesselInventoryService {
     };
   }
 
+  // Reports to Kessel Inventory that a Reporter's representation of a Resource has been deleted.
+  //
+  // This operation is typically used when a resource has been decommissioned or
+  // is no longer reported by any authorized system.
+  //
+  // As a result, relationship checks performed via the `Check` and
+  // `CheckForUpdate` APIs will no longer resolve positively for the deleted
+  // resource. Any decisions that depend on relationships tied to
+  // this resource will be affected.
+  //
+  // As an example, it can revoke previously granted access across the system.
   rpc DeleteResource(DeleteResourceRequest) returns (DeleteResourceResponse) {
     option (google.api.http) = {
       delete: "/api/inventory/v1beta2/resources"
@@ -49,5 +107,15 @@ service KesselInventoryService {
     };
   }
 
+  // Streams a list of objects where the given subject has the specified relation.
+  //
+  // This relationship query answers the question:
+  // "Which objects of type *X* does subject *Y* have the *Z* relation to?"
+  //
+  // It is often used to power user-facing dashboards, filtered UIs, or policy-driven
+  // access lists. The result is streamed incrementally to support large datasets and
+  // reduce client-side latency or memory pressure.
+  //
+  // Pagination and consistency controls allow fine-tuned performance and data freshness.
   rpc StreamedListObjects(StreamedListObjectsRequest) returns (stream StreamedListObjectsResponse);
 }

--- a/src/main/proto/kessel/inventory/v1beta2/report_resource_request.proto
+++ b/src/main/proto/kessel/inventory/v1beta2/report_resource_request.proto
@@ -10,19 +10,41 @@ option go_package = "github.com/project-kessel/inventory-api/api/kessel/inventor
 option java_multiple_files = true;
 option java_package = "org.project_kessel.api.inventory.v1beta2";
 
+// Request to register or update a *Reporter*'s *Representation* of a *Resource* in Kessel Inventory.
 message ReportResourceRequest {
+  // The Kessel Inventory-assigned ID of the *Resource*.
+  //
+  // Usually not required during reporting; populated internally during correlation.
   optional string inventory_id = 1;
+  // The canonical type of the *Resource* (e.g., "k8s_cluster", "host", "integration").
+  //
+  // Must be a previously agreed-upon value between the *Reporter* and Kessel Inventory.
+  // Must be consistent across all *Reporter Representations* of a given Type reported by a given *Reporter*.
+  // Used to:
+  // - Select the appropriate schema to validate the *Reporter Representation*
+  // - Identify a *Reporter's Representation* uniquely in Kessel Inventory
   string type = 2 [(buf.validate.field).string = {min_len: 1}];
+  // The type of the *Reporter* (e.g., "hbi", "acm", "acs", "notifications").
+  //
+  // Must be a previously agreed-upon value between the *Reporter* and Kessel Inventory.
+  // Must be consistent across all *Reporter Representations* reported by a given *Reporter*.
+  // Used to:
+  // - Select the appropriate schema to validate the *Reporter Representation*
+  // - Identify a *Reporter's Representation* uniquely in Kessel Inventory
   string reporter_type = 3 [(buf.validate.field).string = {min_len: 1}];
+  // Identifier for the specific instance of the *Reporter*.
+  // This may not be applicable to all Reporters
+  //
+  // Used to distinguish between multiple instances of the same `reporter_type`.
+  // Does not require prior coordination with Kessel Inventory.
   string reporter_instance_id = 4 [(buf.validate.field).string = {min_len: 1}];
   ResourceRepresentations representations = 5 [(buf.validate.field).required = true];
-  // WriteVisibility specifies the behavior of the write operation.
-  // - WRITE_VISIBILITY_UNSPECIFIED: The default behavior of the write operation. Defaults to MINIMIZE_LATENCY
-  //   strategy.
-  // - MINIMIZE_LATENCY: The write operation will be performed with the goal of minimizing latency
-  //   by not waiting for data consistency acknowledgment.
-  // - IMMEDIATE: The write operation will be performed with the goal of ensuring immediate consistency
-  //   by waiting for data consistency acknowledgment. Additional
-  //   latency may be incurred.
+  // Controls the visibility guarantees of the write operation in Kessel Inventory.
+  //
+  // - `MINIMIZE_LATENCY` (default): Optimizes for throughput; may delay visibility in `Check` results.
+  // - `IMMEDIATE`: Ensures read-your-writes consistency; higher latency due to synchronization.
+  //
+  // Use `IMMEDIATE` only if your use case requires strong consistency guarantees
+  // (e.g., writing and immediately checking access to the resource).
   WriteVisibility write_visibility = 6 [(buf.validate.field).enum.defined_only = true];
 }

--- a/src/main/proto/kessel/inventory/v1beta2/write_visibility.proto
+++ b/src/main/proto/kessel/inventory/v1beta2/write_visibility.proto
@@ -7,7 +7,14 @@ option java_multiple_files = true;
 option java_package = "org.project_kessel.api.inventory.v1beta2";
 
 enum WriteVisibility {
+  // WRITE_VISIBILITY_UNSPECIFIED: The default behavior of the write operation. Defaults to MINIMIZE_LATENCY
+  //   strategy.
   WRITE_VISIBILITY_UNSPECIFIED = 0;
+  // MINIMIZE_LATENCY: The write operation will be performed with the goal of minimizing latency
+  //  by not waiting for data consistency acknowledgment.
   MINIMIZE_LATENCY = 1;
+  // IMMEDIATE: The write operation will be performed with the goal of ensuring immediate consistency
+  //  by waiting for data consistency acknowledgment. Additional
+  //  latency may be incurred
   IMMEDIATE = 2;
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-39359

- Updates sync job to properly move v1beta1 protos into their own directories
- - Moves v1beta1 protos into proper directory structure
- Adds a `KesselInventoryClient` to use the new v1beta2 service endpoints.
- Updates caller.java with v1beta2 example calls for `Check`, `CheckForUpdate`, `ReportResource`, `DeleteResource`, and `StreamedListObjects`.

## Summary by Sourcery

Update the client to support v1beta2 inventory service endpoints and improve proto file organization

New Features:
- Add KesselInventoryClient to support v1beta2 service endpoints

Enhancements:
- Reorganize v1beta1 proto files into subdirectories for better structure

Chores:
- Update logging in existing client classes to use correct class names